### PR TITLE
use `OnApplicationShutdown` lifecycle to close connections

### DIFF
--- a/dist/cluster-core.module.d.ts
+++ b/dist/cluster-core.module.d.ts
@@ -1,11 +1,11 @@
-import { DynamicModule, OnModuleDestroy } from '@nestjs/common';
+import { DynamicModule, OnApplicationShutdown } from '@nestjs/common';
 import { RedisClusterModuleAsyncOptions, RedisClusterModuleOptions } from './cluster.interface';
 import { RedisClusterProvider } from './cluster.provider';
-export declare class ClusterCoreModule implements OnModuleDestroy {
+export declare class ClusterCoreModule implements OnApplicationShutdown {
     private readonly options;
     private readonly provider;
     constructor(options: RedisClusterModuleOptions | RedisClusterModuleOptions[], provider: RedisClusterProvider);
     static register(options: RedisClusterModuleOptions | RedisClusterModuleOptions[]): DynamicModule;
     static forRootAsync(options: RedisClusterModuleAsyncOptions): DynamicModule;
-    onModuleDestroy(): void;
+    onApplicationShutdown(): void;
 }

--- a/dist/cluster-core.module.js
+++ b/dist/cluster-core.module.js
@@ -41,7 +41,7 @@ let ClusterCoreModule = ClusterCoreModule_1 = class ClusterCoreModule {
             exports: [cluster_service_1.RedisClusterService],
         };
     }
-    onModuleDestroy() {
+    onApplicationShutdown() {
         const closeConnection = ({ clusters, defaultKey, }) => options => {
             const name = options.name || defaultKey;
             const cluster = clusters.get(name);

--- a/dist/redis-core.module.d.ts
+++ b/dist/redis-core.module.d.ts
@@ -1,11 +1,11 @@
-import { DynamicModule, OnModuleDestroy } from '@nestjs/common';
+import { DynamicModule, OnApplicationShutdown } from '@nestjs/common';
 import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
 import { RedisClient } from './redis.provider';
-export declare class RedisCoreModule implements OnModuleDestroy {
+export declare class RedisCoreModule implements OnApplicationShutdown {
     private readonly options;
     private readonly redisClient;
     constructor(options: RedisModuleOptions | RedisModuleOptions[], redisClient: RedisClient);
     static register(options: RedisModuleOptions | RedisModuleOptions[]): DynamicModule;
     static forRootAsync(options: RedisModuleAsyncOptions): DynamicModule;
-    onModuleDestroy(): void;
+    onApplicationShutdown(): void;
 }

--- a/dist/redis-core.module.js
+++ b/dist/redis-core.module.js
@@ -41,7 +41,7 @@ let RedisCoreModule = RedisCoreModule_1 = class RedisCoreModule {
             exports: [redis_service_1.RedisService],
         };
     }
-    onModuleDestroy() {
+    onApplicationShutdown() {
         const closeConnection = ({ clients, defaultKey }) => options => {
             const name = options.name || defaultKey;
             const client = clients.get(name);

--- a/lib/cluster-core.module.ts
+++ b/lib/cluster-core.module.ts
@@ -3,7 +3,7 @@ import {
   Global,
   Module,
   Inject,
-  OnModuleDestroy,
+  OnApplicationShutdown,
 } from '@nestjs/common';
 import * as IORedis from 'ioredis';
 
@@ -27,7 +27,7 @@ import { RedisClusterService } from './cluster.service';
   providers: [RedisClusterService],
   exports: [RedisClusterService],
 })
-export class ClusterCoreModule implements OnModuleDestroy {
+export class ClusterCoreModule implements OnApplicationShutdown {
   constructor(
     @Inject(REDIS_CLUSTER_MODULE_OPTIONS)
     private readonly options:
@@ -60,7 +60,7 @@ export class ClusterCoreModule implements OnModuleDestroy {
     };
   }
 
-  onModuleDestroy() {
+  onApplicationShutdown() {
     const closeConnection = ({
       clusters,
       defaultKey,

--- a/lib/redis-core.module.ts
+++ b/lib/redis-core.module.ts
@@ -3,7 +3,7 @@ import {
   Global,
   Module,
   Inject,
-  OnModuleDestroy,
+  OnApplicationShutdown,
 } from '@nestjs/common';
 import { RedisModuleAsyncOptions, RedisModuleOptions } from './redis.interface';
 import {
@@ -20,7 +20,7 @@ import { RedisService } from './redis.service';
   providers: [RedisService],
   exports: [RedisService],
 })
-export class RedisCoreModule implements OnModuleDestroy {
+export class RedisCoreModule implements OnApplicationShutdown {
   constructor(
     @Inject(REDIS_MODULE_OPTIONS)
     private readonly options: RedisModuleOptions | RedisModuleOptions[],
@@ -50,7 +50,7 @@ export class RedisCoreModule implements OnModuleDestroy {
     };
   }
 
-  onModuleDestroy() {
+  onApplicationShutdown() {
     const closeConnection = ({ clients, defaultKey }) => options => {
       const name = options.name || defaultKey;
       const client = clients.get(name);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-redis-cluster",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A nestjs redis module w/ cluster support",
   "author": "Ishmael Samuel (useparagon.com)",
   "license": "MIT",


### PR DESCRIPTION
This PR refactors the modules to use the `OnApplicationShutdown` instead of `OnModuleDestroy` to prevent race conditions of other modules that use `OnModuleDestroy`.