### PR TITLE
chore > upgrade uuid from 3.3.2 to 8.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
     "lint": "tslint -p tsconfig.json -c tslint.json"
   },
   "dependencies": {
-    "@types/uuid": "^3.4.4",
     "reflect-metadata": "0.1.13",
     "rxjs": "^7.3.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@nestjs/common": "^8.0.7",
@@ -31,6 +30,7 @@
     "@nestjs/testing": "^8.0.7",
     "@types/ioredis": "^4.28.5",
     "@types/node": "^10.7.1",
+    "@types/uuid": "^8.3.2",
     "cz-conventional-changelog": "^2.1.0",
     "ioredis": "^4.28.5",
     "jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-redis-cluster",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "A nestjs redis module w/ cluster support",
   "author": "Ishmael Samuel (useparagon.com)",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,11 +74,10 @@
   version "10.12.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
 
-"@types/uuid@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
-  dependencies:
-    "@types/node" "*"
+"@types/uuid@^8.3.2":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 abab@^2.0.0:
   version "2.0.0"
@@ -3418,7 +3417,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@8.3.2:
+uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
**Overview**
upgrade `uuid` package to `8.3.2` so that it expose `validate` function that check if string is valid uuid or not.
As `@types/uuid` is defined as `devDependencies` it is listed in `paraon monorepo`'s yarn.lock file , which dont let us use `validate` method there https://github.com/useparagon/paragon/pull/8477