### PR TITLE
fix > broken build with `uuid`

### DIFF
--- a/dist/cluster.provider.js
+++ b/dist/cluster.provider.js
@@ -41,7 +41,7 @@ exports.createCluster = () => ({
     provide: cluster_constants_1.REDIS_CLUSTER,
     useFactory: (options) => __awaiter(void 0, void 0, void 0, function* () {
         const clusters = new Map();
-        let defaultKey = uuid();
+        let defaultKey = uuid.v4();
         if (Array.isArray(options)) {
             yield Promise.all(options.map((o) => __awaiter(void 0, void 0, void 0, function* () {
                 const key = o.name || defaultKey;

--- a/dist/redis.provider.js
+++ b/dist/redis.provider.js
@@ -41,7 +41,7 @@ exports.createClient = () => ({
     provide: redis_constants_1.REDIS_CLIENT,
     useFactory: (options) => __awaiter(void 0, void 0, void 0, function* () {
         const clients = new Map();
-        let defaultKey = uuid();
+        let defaultKey = uuid.v4();
         if (Array.isArray(options)) {
             yield Promise.all(options.map((o) => __awaiter(void 0, void 0, void 0, function* () {
                 const key = o.name || defaultKey;

--- a/lib/cluster.provider.ts
+++ b/lib/cluster.provider.ts
@@ -41,7 +41,7 @@ export const createCluster = (): Provider => ({
       string,
       IORedis.Cluster
     >();
-    let defaultKey = uuid();
+    let defaultKey = uuid.v4();
 
     if (Array.isArray(options)) {
       await Promise.all(

--- a/lib/redis.provider.ts
+++ b/lib/redis.provider.ts
@@ -27,7 +27,7 @@ export const createClient = (): Provider => ({
     options: RedisModuleOptions | RedisModuleOptions[],
   ): Promise<RedisClient> => {
     const clients = new Map<string, IORedis.Redis>();
-    let defaultKey = uuid();
+    let defaultKey = uuid.v4();
 
     if (Array.isArray(options)) {
       await Promise.all(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-redis-cluster",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A nestjs redis module w/ cluster support",
   "author": "Ishmael Samuel (useparagon.com)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/testing": "^8.0.7",
     "@types/ioredis": "^4.28.5",
     "@types/node": "^10.7.1",
+    "@types/uuid": "^8.3.2",
     "cz-conventional-changelog": "^2.1.0",
     "ioredis": "^4.28.5",
     "jest": "^23.6.0",
@@ -46,7 +47,7 @@
     "@nestjs/core": "^8.0.0",
     "ioredis": "4.x",
     "rxjs": "^7.0.0",
-    "uuid": "^3.0.0"
+    "uuid": "^8.3.2"
   },
   "keywords": [
     "nestjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,11 @@
   version "10.12.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
 
+"@types/uuid@^8.3.2":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"


### PR DESCRIPTION
**Overview**
https://github.com/useparagon/nestjs-redis-cluster/pull/14 build has breaking api for  `uuid` lib with `^8.3.0` as `uuid()` throwing error

**Changes**
- use `uuid.v4()` 
- add `@types/uuid` package