### PR TITLE
(feat)-PARA-10748: add option to restrict client closure on shutdown

### DIFF
--- a/lib/cluster-core.module.ts
+++ b/lib/cluster-core.module.ts
@@ -68,7 +68,7 @@ export class ClusterCoreModule implements OnApplicationShutdown {
       const name = options.name || defaultKey;
       const cluster: IORedis.Cluster = clusters.get(name);
 
-      if (cluster && !options.keepAlive) {
+      if (cluster && !options.disableDisconnectOnShutdown) {
         cluster.disconnect();
       }
     };

--- a/lib/cluster.interface.ts
+++ b/lib/cluster.interface.ts
@@ -3,9 +3,26 @@ import { ClusterOptions } from 'ioredis';
 import * as IORedis from 'ioredis';
 
 export interface RedisClusterModuleOptions extends ClusterOptions {
+  /**
+   * redis connection name
+   */
   name?: string;
+
+  /**
+   * redis cluster nodes
+   */
   nodes: (string | number | object)[];
+
+  /**
+   * callback to execute once cluster is connected & is in ready state
+   */
   onClusterReady?(cluster: IORedis.Cluster): Promise<void>;
+
+  /**
+   * when `true`, doesn't close the redis connections on app shutdown, instead
+   * delegates connection closure responsibility to the consumer via clusterService#disconnectAllClients
+   */
+  disableDisconnectOnShutdown?: boolean;
 }
 
 export interface RedisClusterModuleAsyncOptions

--- a/lib/cluster.service.ts
+++ b/lib/cluster.service.ts
@@ -1,13 +1,18 @@
 import { Injectable, Inject } from '@nestjs/common';
 import * as IORedis from 'ioredis';
 
-import { REDIS_CLUSTER } from './cluster.constants';
+import { REDIS_CLUSTER, REDIS_CLUSTER_MODULE_OPTIONS } from './cluster.constants';
 import { RedisClusterProvider, RedisClusterError } from './cluster.provider';
+import { RedisClusterModuleOptions } from './cluster.interface';
 
 @Injectable()
 export class RedisClusterService {
   constructor(
-    @Inject(REDIS_CLUSTER) private readonly provider: RedisClusterProvider,
+    @Inject(REDIS_CLUSTER)
+    private readonly provider: RedisClusterProvider,
+
+    @Inject(REDIS_CLUSTER_MODULE_OPTIONS)
+    private readonly options: RedisClusterModuleOptions | RedisClusterModuleOptions[],
   ) {}
 
   getCluster(name?: string): IORedis.Cluster {
@@ -23,5 +28,26 @@ export class RedisClusterService {
 
   getClusters(): Map<string, IORedis.Cluster> {
     return this.provider.clusters;
+  }
+
+  disconnectAllClients(): void {
+    const closeConnection =
+      ({ clusters, defaultKey }: RedisClusterProvider) =>
+      (options: RedisClusterModuleOptions) => {
+        const name = options.name || defaultKey;
+        const cluster: IORedis.Cluster = clusters.get(name) as IORedis.Cluster;
+
+        if (cluster) {
+          cluster.disconnect();
+        }
+      };
+
+    const closeClusterConnection = closeConnection(this.provider);
+
+    if (Array.isArray(this.options)) {
+      this.options.forEach(closeClusterConnection);
+    } else {
+      closeClusterConnection(this.options);
+    }
   }
 }

--- a/lib/redis-core.module.ts
+++ b/lib/redis-core.module.ts
@@ -55,7 +55,7 @@ export class RedisCoreModule implements OnApplicationShutdown {
       const name = options.name || defaultKey;
       const client = clients.get(name);
 
-      if (client && !options.keepAlive) {
+      if (client && !options.keepAlive && !options.disableDisconnectOnShutdown) {
         client.disconnect();
       }
     };

--- a/lib/redis.interface.ts
+++ b/lib/redis.interface.ts
@@ -2,9 +2,26 @@ import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { Redis, RedisOptions } from 'ioredis';
 
 export interface RedisModuleOptions extends RedisOptions {
+  /**
+   * redis connection anme
+   */
   name?: string;
+
+  /**
+   * redis connection url
+   */
   url?: string;
+
+  /**
+   * callback to execute once client has connected and is in ready state
+   */
   onClientReady?(client: Redis): Promise<void>;
+
+  /**
+   * when `true`, doesn't close the redis connections on app shutdown, instead
+   * delegates connection closure responsibility to the consumer via redisService#disconnectAllClients
+   */
+  disableDisconnectOnShutdown?: boolean;
 }
 
 export interface RedisModuleAsyncOptions

--- a/lib/redis.service.ts
+++ b/lib/redis.service.ts
@@ -1,12 +1,18 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { REDIS_CLIENT } from './redis.constants';
 import * as IORedis from 'ioredis';
+
+import { REDIS_CLIENT, REDIS_MODULE_OPTIONS } from './redis.constants';
 import { RedisClient, RedisClientError } from './redis.provider';
+import { RedisModuleOptions } from './redis.interface';
 
 @Injectable()
 export class RedisService {
   constructor(
-    @Inject(REDIS_CLIENT) private readonly redisClient: RedisClient,
+    @Inject(REDIS_CLIENT) 
+    private readonly redisClient: RedisClient,
+
+    @Inject(REDIS_MODULE_OPTIONS)
+    private readonly options: RedisModuleOptions | RedisModuleOptions[]
   ) {}
 
   getClient(name?: string): IORedis.Redis {
@@ -21,5 +27,26 @@ export class RedisService {
 
   getClients(): Map<string, IORedis.Redis> {
     return this.redisClient.clients;
+  }
+
+  disconnectAllClients(): void {
+    const closeConnection =
+      ({ clients, defaultKey }) =>
+      (options: RedisModuleOptions) => {
+        const name = options.name || defaultKey;
+        const client = clients.get(name) as IORedis.Redis;
+
+        if (client && !options.keepAlive) {
+          client.disconnect();
+        }
+      };
+
+    const closeClientConnection = closeConnection(this.redisClient);
+
+    if (Array.isArray(this.options)) {
+      this.options.forEach(closeClientConnection);
+    } else {
+      closeClientConnection(this.options);
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-redis-cluster",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "A nestjs redis module w/ cluster support",
   "author": "Ishmael Samuel (useparagon.com)",
   "license": "MIT",


### PR DESCRIPTION
This PR adds an option `disableDisconnectOnShutdown`, which when `true` restricts the _redis_ client disconnection on application shutdown.

When `disableDisconnectOnShutdown` is `true` the client disconnection responsibility falls on the consumer of this service. They can disconnect the clients via the new `disconnectAllClients` method in cluster & redis services.

Here're the corresponding changes that would have to be done in the paragon monorepo to use this: https://github.com/useparagon/paragon/pull/8784

@ishmaelthedestroyer Can you pl also publish a new stable version if this looks good to you? @anakshiant already published an [2.1.0-experimental](https://www.npmjs.com/package/nestjs-redis-cluster/v/2.1.0-experimental) build w/ these changes.

✅ Note: These changes have been verified on `nueve` via [this PR](https://github.com/useparagon/paragon/pull/8760), wherein, the `nestjs-redis-cluster` code was moved inside the monorepo to test the functionality out.