### PR TITLE
fix(infra): Updated upload-artifacts version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
         run: yarn build
 
       - name: ci > upload artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
         with:
           name: dist
           path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ src/test
 logs/
 *.thrift
 *.sql
+.idea

--- a/.whiskers/workflows/build.workflow.ts
+++ b/.whiskers/workflows/build.workflow.ts
@@ -35,7 +35,7 @@ export default new GithubActionWorkflow({
         }),
         new GithubActionWorkflowStep<ActionsStepConfig<any>>({
           name: 'ci > upload artifacts',
-          uses: 'actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32', // v3.1.3
+          uses: 'actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808', // v4.3.3
           with: {
             name: 'dist',
             path: 'dist/',


### PR DESCRIPTION
### Issues Closed

- [PARA-12355](https://useparagon.atlassian.net/browse/PARA-12355)

### Brief Summary

Updated upload-artifacts from v3 to v4 to avoid deprecation issues

### Detailed Summary

Artifact actions v3 will be closing down by January 30, 2025. After this date, all actions using v3 will result in a failure. These changes bump the upload-artifact version from v3 to v4

### Changes

- Updated upload-artifacts from v3.1.3 to v4.3.3

### Steps to Test

Apply changes and verify the actions run successfully

[PARA-12355]: https://useparagon.atlassian.net/browse/PARA-12355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ